### PR TITLE
Put generated moc_* and *.o files in separate folders

### DIFF
--- a/common.pri
+++ b/common.pri
@@ -3,6 +3,9 @@ win32:CONFIG += release warn_off
 !win32:CONFIG += debug
 PKGCONFIG = freetype2
 
+MOC_DIR = moc
+OBJECTS_DIR = obj
+
 QMAKE_CXXFLAGS += $$system(mkoctfile -p ALL_CXXFLAGS)
 win32 {
 	#QMAKE_CXXFLAGS_WARN_ON -= -W3


### PR DESCRIPTION
I like to not clutter up my src directories with generated files. Feel free to ignore this if you don't like additional folders.

Signed-off-by: Thorsten Liebig Thorsten.Liebig@gmx.de
